### PR TITLE
i18n(cs): Add Czech translation

### DIFF
--- a/i18n/cs/cosmic_applet_clippy_land.ftl
+++ b/i18n/cs/cosmic_applet_clippy_land.ftl
@@ -1,0 +1,2 @@
+empty = Schránka je prázdná
+remove = Odstranit

--- a/resources/app.metainfo.xml
+++ b/resources/app.metainfo.xml
@@ -5,9 +5,12 @@
   <project_license>GPL-3.0-or-later</project_license>
   <name>Clippy Land</name>
   <summary>Clipboard history applet for COSMIC</summary>
+  <summary xml:lang="cs">Applet historie schránky pro COSMIC</summary>
   <description>
     <p>A COSMIC panel applet that keeps a history of recently copied text.</p>
+    <p xml:lang="cs">Applet pro panel COSMIC, který udržuje historii nedávno zkopírovaného textu.</p>
     <p>Use it to quickly re-select and re-use clipboard entries from the panel.</p>
+    <p xml:lang="cs">Umožňuje s rychlostí znovu vybrat a použít záznamy schránky přímo z panelu.</p>
   </description>
   <icon type="stock">com.keewee.CosmicAppletClippyLand</icon>
   <launchable type="desktop-id">com.keewee.CosmicAppletClippyLand.desktop</launchable>

--- a/resources/com.keewee.CosmicAppletClippyLand.desktop
+++ b/resources/com.keewee.CosmicAppletClippyLand.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Name=Clippy Land
 Comment=Clipboard history applet for COSMIC
+Comment[cs]=Applet historie schránky pro COSMIC
 Type=Application
 Icon=com.keewee.CosmicAppletClippyLand
 Exec=cosmic-applet-clippy-land %F


### PR DESCRIPTION
Hi ! Thanks for the applet. This adds Czech language as the title says.

---

Additionally, I'm using Fedora and I made myself an RPM version on COPR
- https://copr.fedorainfracloud.org/coprs/kordus/cosmic-applets

I think it could be useful to others. If you want, feel free to add it to README as an unofficial method of installation.

The instructions for Fedora users are there as well, but to be absolutely clear:

Fedora Workstation
```sh
sudo dnf copr enable kordus/cosmic-applets
sudo dnf install cosmic-applet-clippy-land
```

Fedora Atomic
```sh
sudo wget -O /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:kordus:cosmic-applets.repo https://copr.fedorainfracloud.org/coprs/kordus/cosmic-applets/repo/fedora/kordus-cosmic-applets.repo
rpm-ostree install cosmic-applet-clippy-land
```