### PR TITLE
Sort translations alphabetically & Update Czech translation

### DIFF
--- a/i18n/cs/cosmic_applet_clippy_land.ftl
+++ b/i18n/cs/cosmic_applet_clippy_land.ftl
@@ -4,3 +4,4 @@ pin = Připnout
 unpin = Odepnout
 delete-all = Vymazat historii
 search-placeholder = Hledat v historii schránky
+no-results = Nenalezeny žádné výsledky

--- a/resources/io.github.k33wee.clippy-land.desktop
+++ b/resources/io.github.k33wee.clippy-land.desktop
@@ -1,9 +1,9 @@
 [Desktop Entry]
 Name=Clippy Land
 Comment=Clipboard history applet for COSMIC
+Comment[cs]=Applet historie schránky pro COSMIC
 Comment[it]=COSMIC applet per la cronologia della clipboard
 Comment[pt]=Applet de busca no histórico da área de transferência para COSMIC
-Comment[cs]=Applet historie schránky pro COSMIC
 Type=Application
 Icon=io.github.k33wee.clippy-land-symbolic
 Exec=cosmic-applet-clippy-land

--- a/resources/io.github.k33wee.clippy-land.metainfo.xml
+++ b/resources/io.github.k33wee.clippy-land.metainfo.xml
@@ -5,7 +5,7 @@
   <project_license>GPL-3.0-or-later</project_license>
   <name>Clippy Land</name>
   <summary>Clipboard history for COSMIC panel</summary>
-  <summary xml:lang="cs">Applet historie schránky pro COSMIC</summary>
+  <summary xml:lang="cs">Historie schránky pro panel COSMIC</summary>
   <developer id="io.github.k33wee">
     <name>k33wee</name>
   </developer>
@@ -13,18 +13,28 @@
     <p>Clippy Land is a COSMIC panel applet that keeps a history of recently copied text and images.
     Click the panel icon to browse, re-copy, pin, or delete clipboard entries without leaving your workflow.
     Note: this applet only works on the COSMIC™ desktop environment.</p>
+    <p xml:lang="cs">Clippy Land je applet pro panel COSMIC, který uchovává historii nedávno zkopírovaného textu a obrázků.
+    Kliknutím na ikonu v panelu můžete procházet, znovu kopírovat, připínat nebo mazat položky schránky, aniž byste museli přerušit svou práci.
+    Poznámka: Tento applet funguje pouze v prostředí COSMIC™.</p>
+    <p xml:lang="it">COSMIC panel applet che mantiene la cronologia del testo e delle immagini copiati.</p>
+    <p xml:lang="pt">Um applet para o painel COSMIC que mantém histórico de cópias recentes de texto e imagens.</p>
+
     <p>Features:</p>
+    <p xml:lang="cs">Funkce:</p>
+
     <ul>
       <li>Stores up to 30 clipboard entries (text and images)</li>
       <li>Re-copy any entry with a single click</li>
       <li>Pin up to 5 important entries so they stay at the top</li>
       <li>Remove individual entries or clear the entire history at once</li>
       <li>Keyboard navigation with arrow keys (or Vim-style h/j/k/l)</li>
+
+      <li xml:lang="cs">Uložení až 30 položek schránky (text a obrázky)</li>
+      <li xml:lang="cs">Znovu zkopírování libovolné položky jediným kliknutím</li>
+      <li xml:lang="cs">Připnutí až 5 důležitých položek tak, aby zůstaly nahoře</li>
+      <li xml:lang="cs">Odstranění jednotlivých položek nebo vymazání celé historie najednou</li>
+      <li xml:lang="cs">Ovládání pomocí klávesnice šipkami (nebo styl Vim: h/j/k/l)</li>
     </ul>
-    <!-- Translations below -->
-    <p xml:lang="cs">Applet pro panel COSMIC, který uchovává historii nedávno zkopírovaného textu a obrázků.</p>
-    <p xml:lang="it">COSMIC panel applet che mantiene la cronologia del testo e delle immagini copiati.</p>
-    <p xml:lang="pt">Um applet para o painel COSMIC que mantém histórico de cópias recentes de texto e imagens.</p>
   </description>
   <icon type="stock">io.github.k33wee.clippy-land</icon>
   <launchable type="desktop-id">io.github.k33wee.clippy-land.desktop</launchable>
@@ -53,6 +63,15 @@
     <keyword>Wayland</keyword>
     <keyword>copy</keyword>
     <keyword>paste</keyword>
+    
+    <keyword xml:lang="cs">schránka</keyword>
+    <keyword xml:lang="cs">historie</keyword>
+    <keyword xml:lang="cs">panel</keyword>
+    <keyword xml:lang="cs">applet</keyword>
+    <keyword xml:lang="cs">COSMIC</keyword>
+    <keyword xml:lang="cs">Wayland</keyword>
+    <keyword xml:lang="cs">kopírovat</keyword>
+    <keyword xml:lang="cs">vložit</keyword>
   </keywords>
   <screenshots>
     <screenshot type="default">

--- a/resources/io.github.k33wee.clippy-land.metainfo.xml
+++ b/resources/io.github.k33wee.clippy-land.metainfo.xml
@@ -10,12 +10,16 @@
     <name>k33wee</name>
   </developer>
   <description>
-    <p>Clippy Land is a COSMIC panel applet that keeps a history of recently copied text and images.
-    Click the panel icon to browse, re-copy, pin, or delete clipboard entries without leaving your workflow.
-    Note: this applet only works on the COSMIC™ desktop environment.</p>
-    <p xml:lang="cs">Clippy Land je applet pro panel COSMIC, který uchovává historii nedávno zkopírovaného textu a obrázků.
-    Kliknutím na ikonu v panelu můžete procházet, znovu kopírovat, připínat nebo mazat položky schránky, aniž byste museli přerušit svou práci.
-    Poznámka: Tento applet funguje pouze v prostředí COSMIC™.</p>
+    <p>
+      Clippy Land is a COSMIC panel applet that keeps a history of recently copied text and images.
+      Click the panel icon to browse, re-copy, pin, or delete clipboard entries without leaving your workflow.
+      Note: this applet only works on the COSMIC™ desktop environment.
+    </p>
+    <p xml:lang="cs">
+      Clippy Land je applet pro panel COSMIC, který uchovává historii nedávno zkopírovaného textu a obrázků.
+      Kliknutím na ikonu v panelu můžete procházet, znovu kopírovat, připínat nebo mazat položky schránky, aniž byste museli přerušit svou práci.
+      Poznámka: Tento applet funguje pouze v prostředí COSMIC™.
+    </p>
     <p xml:lang="it">COSMIC panel applet che mantiene la cronologia del testo e delle immagini copiati.</p>
     <p xml:lang="pt">Um applet para o painel COSMIC que mantém histórico de cópias recentes de texto e imagens.</p>
 


### PR DESCRIPTION
#### 1st commit
-  I know this is nitpicky, but most projects have their translations sorted alphabetically and I just find it cleaner

#### 2nd commit
- Hear me out, I know the intention here was to not mix original strings with the localized ones, but unfortunately this creates a problem - appstream complains that there should be only one `ul` tag (see screenshot)
- To keep it kind of separated/clean, I put the translations inside "blocks" divided by empty lines. If you don't like this approach, feel free to edit it or just tell me what I should do

#### Appstream validation with two `ul` tags
<img width="1629" height="1029" alt="Snímek obrazovky_20260420_160647" src="https://github.com/user-attachments/assets/ee5e389b-36ab-4676-8b1f-9820ec24ae12" />