### PR TITLE
Stop polling the Wayland clipboard and use selection events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,15 +881,21 @@ dependencies = [
 name = "cosmic-applet-clippy-land"
 version = "1.0.0"
 dependencies = [
+ "bytes",
  "futures-util",
  "i18n-embed",
  "i18n-embed-fl",
  "image",
  "libcosmic",
+ "os_pipe",
+ "png 0.18.1",
  "rust-embed",
  "serde",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
  "wl-clipboard-rs",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,20 @@ license = "GPL-3.0-or-later"
 description = "Clipboard history applet for COSMIC desktop environment"
 
 [dependencies]
+bytes = "1.12"
 futures-util = "0.3.31"
 i18n-embed-fl = "0.10"
 image = { version = "0.25.8", default-features = false, features = ["png", "jpeg", "webp"] }
+os_pipe = "1.2.3"
+png = "0.18.1"
 rust-embed = "8.7.2"
 serde = { version = "1.0.228", features = ["derive"] }
 tokio = { version = "1.48.0", features = ["full"] }
 toml = "0.9.8"
 wl-clipboard-rs = "0.9.2"
+wayland-client = "0.31.14"
+wayland-protocols = { version = "0.32.13", features = ["client"] }
+wayland-protocols-wlr = { version = "0.3.12", features = ["client"] }
 
 [dependencies.i18n-embed]
 version = "0.16"

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 COSMIC panel applet for keeping a history of recently copied text and images.
 
-This applet polls the Wayland clipboard and updates the history when
-the contents change.
+This applet listens for Wayland data-control selection events and updates the
+history only when the clipboard contents change.
 
 ![applet example](./resources/example.png)
 

--- a/src/app/handlers/history.rs
+++ b/src/app/handlers/history.rs
@@ -13,10 +13,24 @@ pub(super) fn insert_after_pins(history: &mut VecDeque<HistoryItem>, item: Histo
 }
 
 fn reorder_pins_first(history: &mut VecDeque<HistoryItem>) {
-    let pinned: Vec<_> = history.iter().filter(|it| it.pinned).cloned().collect();
-    let unpinned: Vec<_> = history.iter().filter(|it| !it.pinned).cloned().collect();
+    let mut saw_unpinned = false;
+    let already_ordered = history.iter().all(|item| {
+        if item.pinned {
+            !saw_unpinned
+        } else {
+            saw_unpinned = true;
+            true
+        }
+    });
+    if already_ordered {
+        return;
+    }
 
-    history.clear();
+    // Move entries instead of cloning them.  An image entry owns the complete encoded image, so
+    // cloning here would copy several megabytes on every clipboard update.
+    let entries = std::mem::take(history);
+    let (pinned, unpinned): (Vec<_>, Vec<_>) = entries.into_iter().partition(|item| item.pinned);
+
     history.extend(pinned);
     history.extend(unpinned);
 }
@@ -77,17 +91,34 @@ pub(super) fn toggle_pin(
     true
 }
 
-pub(super) fn copy_history_item(item: &HistoryItem) {
-    copy_clipboard_entry(&item.entry);
+pub(super) fn copy_history_item(
+    item: &HistoryItem,
+) -> cosmic::iced::Task<cosmic::Action<crate::app::Message>> {
+    copy_clipboard_entry(&item.entry)
 }
 
-pub(super) fn copy_clipboard_entry(entry: &ClipboardEntry) {
+pub(super) fn copy_clipboard_entry(
+    entry: &ClipboardEntry,
+) -> cosmic::iced::Task<cosmic::Action<crate::app::Message>> {
+    use cosmic::prelude::*;
+
     match entry {
         ClipboardEntry::Text(text) => {
             _ = clipboard::write_clipboard_text(text);
+            Task::none()
         }
         ClipboardEntry::Image { mime, bytes, .. } => {
-            _ = clipboard::write_clipboard_image(mime, bytes);
+            let mime = mime.clone();
+            let bytes = bytes.clone();
+            Task::perform(
+                async move {
+                    _ = tokio::task::spawn_blocking(move || {
+                        clipboard::write_owned_clipboard_image(mime, bytes)
+                    })
+                    .await;
+                },
+                |_| cosmic::Action::None,
+            )
         }
     }
 }

--- a/src/app/handlers/subscription.rs
+++ b/src/app/handlers/subscription.rs
@@ -4,7 +4,6 @@ use crate::services::clipboard;
 use cosmic::iced::Subscription;
 use cosmic::iced::futures::channel::mpsc;
 use futures_util::SinkExt;
-use std::time::Duration;
 
 use cosmic::iced::core::keyboard::key::Named as NamedKey;
 
@@ -14,20 +13,14 @@ pub(super) fn subscription(app: &AppModel) -> Subscription<Message> {
     let mut subs: Vec<Subscription<Message>> = vec![
         Subscription::run_with(std::any::TypeId::of::<ClipboardSubscription>(), |_| {
             cosmic::iced::stream::channel(1, move |mut channel: mpsc::Sender<Message>| async move {
+                let (clipboard_tx, mut clipboard_rx) = tokio::sync::mpsc::channel(1);
+                std::thread::Builder::new()
+                    .name("clipboard-watcher".to_string())
+                    .spawn(move || clipboard::watch_clipboard(clipboard_tx))
+                    .expect("clipboard watcher thread should start");
                 let mut last_seen: Option<clipboard::ClipboardFingerprint> = None;
 
-                loop {
-                    tokio::time::sleep(Duration::from_millis(500)).await;
-
-                    let next = tokio::task::spawn_blocking(clipboard::read_clipboard_entry)
-                        .await
-                        .ok()
-                        .flatten();
-
-                    let Some(next) = next else {
-                        continue;
-                    };
-
+                while let Some(next) = clipboard_rx.recv().await {
                     let next_fp = next.fingerprint();
                     if last_seen.as_ref() == Some(&next_fp) {
                         continue;

--- a/src/app/handlers/tests/clipboard.rs
+++ b/src/app/handlers/tests/clipboard.rs
@@ -52,9 +52,139 @@ fn clipboard_changed_caches_and_prunes_thumbnail_handles() {
 }
 
 #[test]
-fn clipboard_changed_recomputes_filtered_indices_cache() {
+fn thumbnail_result_updates_only_the_matching_image() {
     let mut app = AppModel::default();
-    app.search_query = "ap".into();
+    app.history.push_back(HistoryItem {
+        entry: ClipboardEntry::Image {
+            mime: "image/png".into(),
+            bytes: vec![1, 2, 3, 4].into(),
+            hash: 42,
+            thumbnail_png: None,
+        },
+        pinned: false,
+    });
+    app.pending_thumbnails.insert((42, 4));
+
+    dispatch(
+        &mut app,
+        Message::ThumbnailReady {
+            hash: 42,
+            bytes_len: 4,
+            thumbnail: Some(crate::services::clipboard::ClipboardThumbnail {
+                width: 1,
+                height: 1,
+                rgba: vec![255, 0, 0, 255].into(),
+                png: vec![137, 80, 78, 71].into(),
+            }),
+        },
+    );
+
+    assert!(!app.pending_thumbnails.contains(&(42, 4)));
+    assert!(app.thumbnail_handles.contains_key(&(42, 4)));
+    match &app.history[0].entry {
+        ClipboardEntry::Image { thumbnail_png, .. } => {
+            assert_eq!(thumbnail_png.as_deref(), Some(&[137, 80, 78, 71][..]));
+        }
+        ClipboardEntry::Text(_) => panic!("expected image entry"),
+    }
+}
+
+#[test]
+fn stale_thumbnail_result_is_discarded() {
+    let mut app = AppModel::default();
+    app.pending_thumbnails.insert((42, 4));
+
+    dispatch(
+        &mut app,
+        Message::ThumbnailReady {
+            hash: 42,
+            bytes_len: 4,
+            thumbnail: Some(crate::services::clipboard::ClipboardThumbnail {
+                width: 1,
+                height: 1,
+                rgba: vec![255, 0, 0, 255].into(),
+                png: vec![137, 80, 78, 71].into(),
+            }),
+        },
+    );
+
+    assert!(app.pending_thumbnails.is_empty());
+    assert!(app.thumbnail_handles.is_empty());
+}
+
+#[test]
+fn failed_thumbnail_is_cached_and_not_requeued() {
+    let mut app = AppModel {
+        popup: Some(cosmic::iced::window::Id::unique()),
+        ..Default::default()
+    };
+    app.history.push_back(HistoryItem {
+        entry: ClipboardEntry::Image {
+            mime: "image/png".into(),
+            bytes: vec![1, 2, 3, 4].into(),
+            hash: 42,
+            thumbnail_png: None,
+        },
+        pinned: false,
+    });
+    app.pending_thumbnails.insert((42, 4));
+
+    dispatch(
+        &mut app,
+        Message::ThumbnailReady {
+            hash: 42,
+            bytes_len: 4,
+            thumbnail: None,
+        },
+    );
+
+    assert!(app.pending_thumbnails.is_empty());
+    assert!(app.failed_thumbnails.contains(&(42, 4)));
+}
+
+#[test]
+fn delayed_thumbnail_decode_is_cancelled_after_popup_closes() {
+    let mut app = AppModel::default();
+    app.pending_thumbnails.insert((42, 4));
+
+    dispatch(
+        &mut app,
+        Message::ThumbnailDecodeReady {
+            hash: 42,
+            bytes_len: 4,
+            generation: 0,
+        },
+    );
+
+    assert!(app.pending_thumbnails.is_empty());
+}
+
+#[test]
+fn stale_debounced_thumbnail_decode_does_not_cancel_newer_work() {
+    let mut app = AppModel {
+        thumbnail_schedule_generation: 2,
+        ..Default::default()
+    };
+    app.pending_thumbnails.insert((42, 4));
+
+    dispatch(
+        &mut app,
+        Message::ThumbnailDecodeReady {
+            hash: 42,
+            bytes_len: 4,
+            generation: 1,
+        },
+    );
+
+    assert!(app.pending_thumbnails.contains(&(42, 4)));
+}
+
+#[test]
+fn clipboard_changed_recomputes_filtered_indices_cache() {
+    let mut app = AppModel {
+        search_query: "ap".into(),
+        ..Default::default()
+    };
     app.recompute_filtered_indices();
     assert!(app.filtered_indices.is_empty());
 

--- a/src/app/handlers/tests/history_limits.rs
+++ b/src/app/handlers/tests/history_limits.rs
@@ -17,8 +17,10 @@ fn toggling_pinned_item_moves_it_after_pinned_section() {
 
 #[test]
 fn toggle_pin_respects_max_pinned_limit() {
-    let mut app = AppModel::default();
-    app.settings = test_settings(30, 5);
+    let mut app = AppModel {
+        settings: test_settings(30, 5),
+        ..Default::default()
+    };
 
     for i in 0..app.settings.max_pinned {
         app.history.push_back(text_item(&format!("pin-{i}"), true));
@@ -35,8 +37,10 @@ fn toggle_pin_respects_max_pinned_limit() {
 
 #[test]
 fn clipboard_changed_trims_to_max_history() {
-    let mut app = AppModel::default();
-    app.settings = test_settings(30, 5);
+    let mut app = AppModel {
+        settings: test_settings(30, 5),
+        ..Default::default()
+    };
 
     for i in 0..app.settings.max_history {
         app.history

--- a/src/app/handlers/tests/hover.rs
+++ b/src/app/handlers/tests/hover.rs
@@ -15,9 +15,11 @@ fn hover_entry_sets_hover_state_and_clears_keyboard_focus() {
 
 #[test]
 fn hover_entry_none_clears_hover_state() {
-    let mut app = AppModel::default();
-    app.hovered_index = Some(2);
-    app.hovered_focus = Some((2, FocusPart::Remove));
+    let mut app = AppModel {
+        hovered_index: Some(2),
+        hovered_focus: Some((2, FocusPart::Remove)),
+        ..Default::default()
+    };
 
     dispatch(&mut app, Message::HoverEntry(None));
 

--- a/src/app/handlers/tests/mod.rs
+++ b/src/app/handlers/tests/mod.rs
@@ -38,9 +38,9 @@ pub(super) fn text_item(text: &str, pinned: bool) -> HistoryItem {
 pub(super) fn image_entry(hash: u64) -> ClipboardEntry {
     ClipboardEntry::Image {
         mime: "image/png".to_string(),
-        bytes: vec![1, 2, 3, 4],
+        bytes: vec![1, 2, 3, 4].into(),
         hash,
-        thumbnail_png: Some(vec![137, 80, 78, 71]),
+        thumbnail_png: Some(vec![137, 80, 78, 71].into()),
     }
 }
 

--- a/src/app/handlers/tests/search.rs
+++ b/src/app/handlers/tests/search.rs
@@ -18,8 +18,10 @@ fn search_changed_updates_query_and_clears_hover_and_keyboard() {
 
 #[test]
 fn search_changed_empty_string_clears_query() {
-    let mut app = AppModel::default();
-    app.search_query = "old".into();
+    let mut app = AppModel {
+        search_query: "old".into(),
+        ..Default::default()
+    };
 
     dispatch(&mut app, Message::SearchChanged(String::new()));
 

--- a/src/app/handlers/tests/settings.rs
+++ b/src/app/handlers/tests/settings.rs
@@ -2,15 +2,17 @@ use super::*;
 
 #[test]
 fn toggle_settings_panel_opens_and_prefills_draft() {
-    let mut app = AppModel::default();
-    app.settings = AppSettings {
-        max_history: 444,
-        max_pinned: 33,
-        max_image_bytes: 3 * 1024 * 1024,
-        max_image_dimension_px: 2048,
-        ..AppSettings::default()
-    }
-    .normalized();
+    let mut app = AppModel {
+        settings: AppSettings {
+            max_history: 444,
+            max_pinned: 33,
+            max_image_bytes: 3 * 1024 * 1024,
+            max_image_dimension_px: 2048,
+            ..AppSettings::default()
+        }
+        .normalized(),
+        ..Default::default()
+    };
 
     dispatch(&mut app, Message::ToggleSettingsPanel);
 
@@ -26,8 +28,10 @@ fn toggle_settings_panel_opens_and_prefills_draft() {
 
 #[test]
 fn apply_settings_rejects_invalid_input_with_error() {
-    let mut app = AppModel::default();
-    app.settings_open = true;
+    let mut app = AppModel {
+        settings_open: true,
+        ..Default::default()
+    };
     app.settings_draft.max_history = "not-a-number".into();
     app.settings_draft.max_pinned = "10".into();
     app.settings_draft.max_image_bytes = "1048576".into();
@@ -41,8 +45,10 @@ fn apply_settings_rejects_invalid_input_with_error() {
 
 #[test]
 fn apply_settings_rejects_out_of_range_values() {
-    let mut app = AppModel::default();
-    app.settings_open = true;
+    let mut app = AppModel {
+        settings_open: true,
+        ..Default::default()
+    };
     app.settings_draft.max_history = "1".into();
     app.settings_draft.max_pinned = "0".into();
     app.settings_draft.max_image_bytes = "1048576".into();
@@ -57,8 +63,10 @@ fn apply_settings_rejects_out_of_range_values() {
 
 #[test]
 fn apply_settings_rejects_pinned_greater_than_history() {
-    let mut app = AppModel::default();
-    app.settings_open = true;
+    let mut app = AppModel {
+        settings_open: true,
+        ..Default::default()
+    };
     app.settings_draft.max_history = "100".into();
     app.settings_draft.max_pinned = "101".into();
     app.settings_draft.max_image_bytes = "1048576".into();
@@ -75,8 +83,10 @@ fn apply_settings_rejects_pinned_greater_than_history() {
 
 #[test]
 fn apply_settings_rejects_image_bytes_below_minimum() {
-    let mut app = AppModel::default();
-    app.settings_open = true;
+    let mut app = AppModel {
+        settings_open: true,
+        ..Default::default()
+    };
     app.settings_draft.max_history = "200".into();
     app.settings_draft.max_pinned = "20".into();
     app.settings_draft.max_image_bytes = "1".into();
@@ -98,8 +108,10 @@ fn apply_settings_updates_runtime_settings_and_closes_panel() {
     let cfg_path = std::env::temp_dir().join(format!("clippy-land-test-settings-{unique}.toml"));
     unsafe { std::env::set_var("CLIPPY_LAND_CONFIG", &cfg_path) };
 
-    let mut app = AppModel::default();
-    app.settings_open = true;
+    let mut app = AppModel {
+        settings_open: true,
+        ..Default::default()
+    };
     app.settings_draft.max_history = "350".into();
     app.settings_draft.max_pinned = "30".into();
     app.settings_draft.max_image_bytes = "2097152".into();

--- a/src/app/handlers/update/clipboard.rs
+++ b/src/app/handlers/update/clipboard.rs
@@ -1,25 +1,33 @@
-use super::shared::{cache_thumbnail_handle, prune_thumbnail_handles};
+use super::shared::{
+    cache_thumbnail_handle, decode_thumbnail, prune_thumbnail_handles, schedule_missing_thumbnails,
+    schedule_missing_thumbnails_after_clipboard_change,
+};
 use crate::app::model::HistoryItem;
 use crate::app::{AppModel, Message, pinned_history};
 use crate::services::clipboard::ClipboardEntry;
+use cosmic::iced::widget::image::Handle as ImageHandle;
+use cosmic::prelude::*;
 
 use super::super::history;
 
-pub(super) fn handle(app: &mut AppModel, message: Message) -> bool {
+pub(super) fn handle(
+    app: &mut AppModel,
+    message: Message,
+) -> Option<Task<cosmic::Action<Message>>> {
     match message {
         Message::ClipboardChanged(entry) => {
             if app
                 .history
                 .front()
-                .is_some_and(|it: &HistoryItem| &it.entry == &entry)
+                .is_some_and(|it: &HistoryItem| it.entry == entry)
             {
-                return true;
+                return Some(Task::none());
             }
 
-            if let ClipboardEntry::Text(text) = &entry {
-                if history::should_ignore_clipboard_entry(text) {
-                    return true;
-                }
+            if let ClipboardEntry::Text(text) = &entry
+                && history::should_ignore_clipboard_entry(text)
+            {
+                return Some(Task::none());
             }
 
             cache_thumbnail_handle(app, &entry);
@@ -27,7 +35,7 @@ pub(super) fn handle(app: &mut AppModel, message: Message) -> bool {
             let pinned = app
                 .history
                 .iter()
-                .position(|it| &it.entry == &entry)
+                .position(|it| it.entry == entry)
                 .and_then(|idx| app.history.remove(idx))
                 .is_some_and(|it| it.pinned);
 
@@ -39,7 +47,77 @@ pub(super) fn handle(app: &mut AppModel, message: Message) -> bool {
             if pinned {
                 pinned_history::save(&app.history);
             }
-            true
+
+            if app.popup.is_some() {
+                Some(schedule_missing_thumbnails_after_clipboard_change(app))
+            } else {
+                Some(Task::none())
+            }
+        }
+        Message::ThumbnailReady {
+            hash,
+            bytes_len,
+            thumbnail,
+        } => {
+            let key = (hash, bytes_len);
+            app.pending_thumbnails.remove(&key);
+
+            let Some(thumbnail) = thumbnail else {
+                app.failed_thumbnails.insert(key);
+                return Some(if app.popup.is_some() {
+                    schedule_missing_thumbnails(app)
+                } else {
+                    Task::none()
+                });
+            };
+            let Some(item) = app.history.iter_mut().find(|item| match &item.entry {
+                ClipboardEntry::Image { bytes, hash, .. } => (*hash, bytes.len()) == key,
+                ClipboardEntry::Text(_) => false,
+            }) else {
+                return Some(schedule_missing_thumbnails(app));
+            };
+
+            if let ClipboardEntry::Image { thumbnail_png, .. } = &mut item.entry {
+                *thumbnail_png = Some(thumbnail.png);
+            }
+            app.thumbnail_handles.insert(
+                key,
+                ImageHandle::from_rgba(thumbnail.width, thumbnail.height, thumbnail.rgba),
+            );
+            Some(if app.popup.is_some() {
+                schedule_missing_thumbnails(app)
+            } else {
+                Task::none()
+            })
+        }
+        Message::ThumbnailDecodeReady {
+            hash,
+            bytes_len,
+            generation,
+        } => {
+            let key = (hash, bytes_len);
+            if generation != app.thumbnail_schedule_generation {
+                return Some(Task::none());
+            }
+            if app.popup.is_none() || !app.popup_controls_ready {
+                app.pending_thumbnails.remove(&key);
+                return Some(Task::none());
+            }
+
+            let Some((mime, bytes)) = app.history.iter().find_map(|item| match &item.entry {
+                ClipboardEntry::Image {
+                    mime,
+                    bytes,
+                    hash,
+                    thumbnail_png: None,
+                } if (*hash, bytes.len()) == key => Some((mime.clone(), bytes.clone())),
+                _ => None,
+            }) else {
+                app.pending_thumbnails.remove(&key);
+                return Some(schedule_missing_thumbnails(app));
+            };
+
+            Some(decode_thumbnail(mime, bytes, key))
         }
         Message::TogglePin(index) => {
             if history::toggle_pin(&mut app.history, index, &app.settings) {
@@ -47,7 +125,7 @@ pub(super) fn handle(app: &mut AppModel, message: Message) -> bool {
             }
             app.text_overlay_index = None;
             app.recompute_filtered_indices();
-            true
+            Some(Task::none())
         }
         Message::OpenTextOverlay(index) => {
             if app
@@ -57,17 +135,17 @@ pub(super) fn handle(app: &mut AppModel, message: Message) -> bool {
             {
                 app.text_overlay_index = Some(index);
             }
-            true
+            Some(Task::none())
         }
         Message::CloseTextOverlay => {
             app.text_overlay_index = None;
-            true
+            Some(Task::none())
         }
         Message::CopyFromHistory(index) => {
             if let Some(item) = app.history.get(index) {
-                history::copy_history_item(item);
+                return Some(history::copy_history_item(item));
             }
-            true
+            Some(Task::none())
         }
         Message::RemoveHistory(index) => {
             let removed_pinned = app.history.remove(index).is_some_and(|item| item.pinned);
@@ -77,7 +155,7 @@ pub(super) fn handle(app: &mut AppModel, message: Message) -> bool {
             if removed_pinned {
                 pinned_history::save(&app.history);
             }
-            true
+            Some(Task::none())
         }
         Message::ClearHistory => {
             app.history.retain(|item| item.pinned);
@@ -85,7 +163,7 @@ pub(super) fn handle(app: &mut AppModel, message: Message) -> bool {
             app.text_overlay_index = None;
             app.recompute_filtered_indices();
             pinned_history::save(&app.history);
-            true
+            Some(Task::none())
         }
         Message::SearchChanged(query) => {
             app.search_query = query;
@@ -94,8 +172,8 @@ pub(super) fn handle(app: &mut AppModel, message: Message) -> bool {
             app.hovered_index = None;
             app.hovered_focus = None;
             app.keyboard_focus = None;
-            true
+            Some(Task::none())
         }
-        _ => false,
+        _ => None,
     }
 }

--- a/src/app/handlers/update/mod.rs
+++ b/src/app/handlers/update/mod.rs
@@ -8,8 +8,18 @@ use crate::app::{AppModel, Message};
 use cosmic::prelude::*;
 
 pub(super) fn update(app: &mut AppModel, message: Message) -> Task<cosmic::Action<Message>> {
-    if clipboard::handle(app, message.clone()) {
-        return Task::none();
+    // Clipboard and thumbnail messages own large buffers and are always consumed here.
+    if matches!(
+        &message,
+        Message::ClipboardChanged(_)
+            | Message::ThumbnailDecodeReady { .. }
+            | Message::ThumbnailReady { .. }
+    ) {
+        return clipboard::handle(app, message).unwrap_or_else(Task::none);
+    }
+
+    if let Some(task) = clipboard::handle(app, message.clone()) {
+        return task;
     }
 
     if let Some(task) = navigation::handle(app, message.clone()) {

--- a/src/app/handlers/update/navigation.rs
+++ b/src/app/handlers/update/navigation.rs
@@ -133,7 +133,7 @@ pub(super) fn handle(
                 match part {
                     FocusPart::Entry => {
                         if let Some(item) = app.history.get(idx) {
-                            history::copy_history_item(item);
+                            return Some(history::copy_history_item(item));
                         }
                     }
                     FocusPart::Preview => {
@@ -157,10 +157,10 @@ pub(super) fn handle(
                         }
                     }
                 }
-            } else if let Some(idx) = app.hovered_index {
-                if let Some(item) = app.history.get(idx) {
-                    history::copy_history_item(item);
-                }
+            } else if let Some(idx) = app.hovered_index
+                && let Some(item) = app.history.get(idx)
+            {
+                return Some(history::copy_history_item(item));
             }
             Some(Task::none())
         }

--- a/src/app/handlers/update/popup.rs
+++ b/src/app/handlers/update/popup.rs
@@ -1,4 +1,4 @@
-use super::shared::warm_thumbnail_handles;
+use super::shared::{schedule_missing_thumbnails, warm_thumbnail_handles};
 use crate::app::{AppModel, Message};
 use cosmic::prelude::*;
 use std::time::Instant;
@@ -15,6 +15,7 @@ pub(super) fn handle(
                 app.popup_controls_ready = true;
                 app.note_popup_stage_marker("popup controls ready after popup open");
                 app.note_popup_opened();
+                return Some(schedule_missing_thumbnails(app));
             }
             Some(Task::none())
         }

--- a/src/app/handlers/update/settings.rs
+++ b/src/app/handlers/update/settings.rs
@@ -132,6 +132,7 @@ pub(super) fn handle(app: &mut AppModel, message: Message) -> bool {
                 app.settings.max_image_bytes,
                 app.settings.max_image_dimension_px,
             );
+            app.failed_thumbnails.clear();
             history::reconcile_limits(&mut app.history, &app.settings);
             pinned_history::save(&app.history);
             prune_thumbnail_handles(app);

--- a/src/app/handlers/update/shared.rs
+++ b/src/app/handlers/update/shared.rs
@@ -2,6 +2,9 @@ use crate::app::AppModel;
 use crate::app::view::summary::text_overlay_available;
 use crate::services::clipboard::ClipboardEntry;
 use cosmic::iced::widget::image::Handle as ImageHandle;
+use cosmic::prelude::*;
+
+const THUMBNAIL_DECODE_DELAY: tokio::time::Duration = tokio::time::Duration::from_millis(350);
 
 pub(super) fn cache_thumbnail_handle(app: &mut AppModel, entry: &ClipboardEntry) {
     let ClipboardEntry::Image {
@@ -26,6 +29,12 @@ pub(super) fn prune_thumbnail_handles(app: &mut AppModel) {
             ClipboardEntry::Text(_) => false,
         })
     });
+    app.failed_thumbnails.retain(|key| {
+        app.history.iter().any(|item| match &item.entry {
+            ClipboardEntry::Image { bytes, hash, .. } => key == &(*hash, bytes.len()),
+            ClipboardEntry::Text(_) => false,
+        })
+    });
 }
 
 pub(super) fn warm_thumbnail_handles(app: &mut AppModel) {
@@ -44,6 +53,93 @@ pub(super) fn warm_thumbnail_handles(app: &mut AppModel) {
             .entry((*hash, bytes.len()))
             .or_insert_with(|| ImageHandle::from_bytes(thumbnail_png.clone()));
     }
+}
+
+pub(super) fn schedule_missing_thumbnails(
+    app: &mut AppModel,
+) -> Task<cosmic::Action<crate::app::Message>> {
+    schedule_missing_thumbnails_after(app, tokio::time::Duration::ZERO)
+}
+
+pub(super) fn schedule_missing_thumbnails_after_clipboard_change(
+    app: &mut AppModel,
+) -> Task<cosmic::Action<crate::app::Message>> {
+    app.thumbnail_schedule_generation = app.thumbnail_schedule_generation.wrapping_add(1);
+    app.pending_thumbnails.clear();
+    schedule_missing_thumbnails_after(app, THUMBNAIL_DECODE_DELAY)
+}
+
+fn schedule_missing_thumbnails_after(
+    app: &mut AppModel,
+    delay: tokio::time::Duration,
+) -> Task<cosmic::Action<crate::app::Message>> {
+    if app.popup.is_none() || !app.popup_controls_ready {
+        return Task::none();
+    }
+    if !app.pending_thumbnails.is_empty() {
+        return Task::none();
+    }
+
+    for item in &app.history {
+        let ClipboardEntry::Image {
+            bytes,
+            hash,
+            thumbnail_png,
+            ..
+        } = &item.entry
+        else {
+            continue;
+        };
+
+        let key = (*hash, bytes.len());
+        if thumbnail_png.is_some()
+            || app.thumbnail_handles.contains_key(&key)
+            || app.failed_thumbnails.contains(&key)
+        {
+            continue;
+        }
+        app.pending_thumbnails.insert(key);
+        let generation = app.thumbnail_schedule_generation;
+        return Task::perform(
+            async move {
+                if !delay.is_zero() {
+                    tokio::time::sleep(delay).await;
+                }
+            },
+            move |_| {
+                cosmic::Action::App(crate::app::Message::ThumbnailDecodeReady {
+                    hash: key.0,
+                    bytes_len: key.1,
+                    generation,
+                })
+            },
+        );
+    }
+
+    Task::none()
+}
+
+pub(super) fn decode_thumbnail(
+    mime: String,
+    bytes: bytes::Bytes,
+    key: (u64, usize),
+) -> Task<cosmic::Action<crate::app::Message>> {
+    Task::perform(
+        async move {
+            tokio::task::spawn_blocking(move || {
+                crate::services::clipboard::make_thumbnail(&mime, &bytes)
+            })
+            .await
+            .unwrap_or(None)
+        },
+        move |thumbnail| {
+            cosmic::Action::App(crate::app::Message::ThumbnailReady {
+                hash: key.0,
+                bytes_len: key.1,
+                thumbnail,
+            })
+        },
+    )
 }
 
 pub(super) fn row_has_preview(app: &AppModel, idx: usize) -> bool {

--- a/src/app/messages.rs
+++ b/src/app/messages.rs
@@ -14,6 +14,16 @@ pub enum Message {
     /// Sent when a window loses focus, used to close the layer surface popup.
     WindowUnfocused(Id),
     ClipboardChanged(clipboard::ClipboardEntry),
+    ThumbnailDecodeReady {
+        hash: u64,
+        bytes_len: usize,
+        generation: u64,
+    },
+    ThumbnailReady {
+        hash: u64,
+        bytes_len: usize,
+        thumbnail: Option<clipboard::ClipboardThumbnail>,
+    },
     TogglePin(usize),
     OpenTextOverlay(usize),
     CloseTextOverlay,

--- a/src/app/model/state.rs
+++ b/src/app/model/state.rs
@@ -3,7 +3,7 @@ use crate::settings::AppSettings;
 use cosmic::iced::widget::image::Handle as ImageHandle;
 use cosmic::iced::window::Id;
 use std::cell::RefCell;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use super::timing::PopupOpenTrace;
 
@@ -41,6 +41,12 @@ pub struct AppModel {
     pub(in crate::app) filtered_history_len_cache: usize,
     /// Cached decoded image handles for thumbnails, keyed by (content hash, byte length).
     pub(in crate::app) thumbnail_handles: HashMap<(u64, usize), ImageHandle>,
+    /// Image identities waiting for or currently undergoing popup-preview decoding.
+    pub(in crate::app) pending_thumbnails: HashSet<(u64, usize)>,
+    /// Monotonic generation used to debounce thumbnail work after clipboard updates.
+    pub(in crate::app) thumbnail_schedule_generation: u64,
+    /// Images rejected by the decoder, so reopening the popup does not retry them forever.
+    pub(in crate::app) failed_thumbnails: HashSet<(u64, usize)>,
     /// Index of the history entry the mouse is currently hovering over.
     pub(in crate::app) hovered_index: Option<usize>,
     /// The specific part of a row the mouse is hovering over (index, part)

--- a/src/app/pinned_history.rs
+++ b/src/app/pinned_history.rs
@@ -189,12 +189,13 @@ impl PersistedEntry {
                 let thumbnail_png = self
                     .thumbnail_file
                     .and_then(|file_name| safe_blob_path(blob_dir, &file_name))
-                    .and_then(|path| fs::read(path).ok());
+                    .and_then(|path| fs::read(path).ok())
+                    .map(Into::into);
 
                 Some(HistoryItem {
                     entry: ClipboardEntry::Image {
                         mime,
-                        bytes,
+                        bytes: bytes.into(),
                         hash,
                         thumbnail_png,
                     },
@@ -344,9 +345,9 @@ mod tests {
         HistoryItem {
             entry: ClipboardEntry::Image {
                 mime: "image/png".to_string(),
-                bytes: vec![1, 2, 3, 4, 5],
+                bytes: vec![1, 2, 3, 4, 5].into(),
                 hash,
-                thumbnail_png: Some(vec![137, 80, 78, 71]),
+                thumbnail_png: Some(vec![137, 80, 78, 71].into()),
             },
             pinned,
         }
@@ -379,7 +380,7 @@ mod tests {
                 thumbnail_png,
             } => {
                 assert_eq!(mime, "image/png");
-                assert_eq!(bytes.as_slice(), &[1, 2, 3, 4, 5]);
+                assert_eq!(bytes.as_ref(), &[1, 2, 3, 4, 5]);
                 assert_eq!(*hash, 0xfeed_beef);
                 assert_eq!(thumbnail_png.as_deref(), Some(&[137, 80, 78, 71][..]));
             }

--- a/src/app/view/tests/mod.rs
+++ b/src/app/view/tests/mod.rs
@@ -22,7 +22,7 @@ pub(super) fn push_image(app: &mut AppModel, mime: &str) {
     app.history.push_back(HistoryItem {
         entry: ClipboardEntry::Image {
             mime: mime.to_string(),
-            bytes: vec![],
+            bytes: vec![].into(),
             hash: 0,
             thumbnail_png: None,
         },

--- a/src/app/view/tests/row_state.rs
+++ b/src/app/view/tests/row_state.rs
@@ -32,9 +32,9 @@ fn row_render_state_image_snapshot_keeps_lightweight_metadata_and_handle() {
     app.history.push_back(HistoryItem {
         entry: ClipboardEntry::Image {
             mime: "image/png".into(),
-            bytes: vec![7; 4096],
+            bytes: vec![7; 4096].into(),
             hash: 42,
-            thumbnail_png: Some(thumbnail.clone()),
+            thumbnail_png: Some(thumbnail.clone().into()),
         },
         pinned: true,
     });
@@ -66,9 +66,9 @@ fn row_render_state_image_snapshot_without_cached_handle_keeps_none() {
     app.history.push_back(HistoryItem {
         entry: ClipboardEntry::Image {
             mime: "image/png".into(),
-            bytes: vec![7; 4096],
+            bytes: vec![7; 4096].into(),
             hash: 777,
-            thumbnail_png: Some(vec![1, 2, 3, 4]),
+            thumbnail_png: Some(vec![1, 2, 3, 4].into()),
         },
         pinned: false,
     });

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -135,7 +135,7 @@ fn unix_timestamp_ms() -> std::io::Result<u128> {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map(|duration| duration.as_millis())
-        .map_err(|err| std::io::Error::other(err))
+        .map_err(std::io::Error::other)
 }
 
 fn ipc_timing_log(message: impl std::fmt::Display) {

--- a/src/services/clipboard.rs
+++ b/src/services/clipboard.rs
@@ -2,15 +2,17 @@ mod image;
 mod io;
 mod model;
 mod uri;
+mod watcher;
 
 #[cfg(test)]
 mod tests;
 
-pub use model::{ClipboardEntry, ClipboardFingerprint};
+pub use model::{ClipboardEntry, ClipboardFingerprint, ClipboardThumbnail};
 use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 
 const DEFAULT_MAX_IMAGE_BYTES: usize = 8 * 1024 * 1024;
 const THUMBNAIL_SIZE_PX: u32 = 400;
+const MAX_FULL_FRAME_THUMBNAIL_BYTES: u64 = 64 * 1024 * 1024;
 const DEFAULT_MAX_IMAGE_DIMENSION_PX: u32 = 8192;
 
 static MAX_IMAGE_BYTES: AtomicUsize = AtomicUsize::new(DEFAULT_MAX_IMAGE_BYTES);
@@ -29,14 +31,18 @@ pub(super) fn max_image_dimension_px() -> u32 {
     MAX_IMAGE_DIMENSION_PX.load(Ordering::Relaxed)
 }
 
+/// One-shot compatibility API for callers that do not need change notifications.
+#[allow(dead_code)]
 pub fn read_clipboard_entry() -> Option<ClipboardEntry> {
     io::read_clipboard_entry()
 }
 
+#[allow(dead_code)]
 pub fn read_clipboard_text() -> Option<String> {
     io::read_clipboard_text()
 }
 
+#[allow(dead_code)]
 pub fn read_clipboard_image() -> Option<ClipboardEntry> {
     io::read_clipboard_image()
 }
@@ -45,8 +51,21 @@ pub fn write_clipboard_text(text: &str) -> bool {
     io::write_clipboard_text(text)
 }
 
+#[allow(dead_code)]
 pub fn write_clipboard_image(mime: &str, bytes: &[u8]) -> bool {
     io::write_clipboard_image(mime, bytes)
+}
+
+pub fn write_owned_clipboard_image(mime: String, bytes: bytes::Bytes) -> bool {
+    io::write_owned_clipboard_image(mime, bytes)
+}
+
+pub fn watch_clipboard(sender: tokio::sync::mpsc::Sender<ClipboardEntry>) {
+    watcher::run(sender)
+}
+
+pub fn make_thumbnail(mime: &str, bytes: &bytes::Bytes) -> Option<ClipboardThumbnail> {
+    image::make_thumbnail(mime, bytes)
 }
 
 pub(super) fn debug_log(message: impl std::fmt::Display) {

--- a/src/services/clipboard/image.rs
+++ b/src/services/clipboard/image.rs
@@ -1,6 +1,8 @@
 use super::{
-    ClipboardEntry, THUMBNAIL_SIZE_PX, debug_log, max_image_bytes, max_image_dimension_px,
+    ClipboardEntry, ClipboardThumbnail, MAX_FULL_FRAME_THUMBNAIL_BYTES, THUMBNAIL_SIZE_PX,
+    debug_log, max_image_bytes, max_image_dimension_px,
 };
+use bytes::Bytes;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::io::Cursor;
@@ -19,13 +21,12 @@ pub(super) fn clipboard_entry_from_image_bytes(
     mime.hash(&mut hasher);
     bytes.hash(&mut hasher);
     let hash = hasher.finish();
-    let thumbnail_png = make_thumbnail_png(&mime, &bytes);
 
     Some(ClipboardEntry::Image {
         mime,
-        bytes,
+        bytes: bytes.into(),
         hash,
-        thumbnail_png,
+        thumbnail_png: None,
     })
 }
 
@@ -42,53 +43,196 @@ pub(super) fn clipboard_entry_from_image_path(path: &Path) -> Option<ClipboardEn
     clipboard_entry_from_image_bytes(mime.to_string(), bytes)
 }
 
-fn make_thumbnail_png(mime: &str, bytes: &[u8]) -> Option<Vec<u8>> {
+pub fn make_thumbnail(mime: &str, bytes: &Bytes) -> Option<ClipboardThumbnail> {
+    if mime == "image/png" {
+        return make_png_thumbnail(bytes);
+    }
+
     let max_dimension = max_image_dimension_px();
-    if !image_dimensions_within_limit(bytes, max_dimension) {
+    let format = match mime {
+        "image/jpeg" => image::ImageFormat::Jpeg,
+        "image/webp" => image::ImageFormat::WebP,
+        _ => image::guess_format(bytes).ok()?,
+    };
+
+    let mut reader = image::ImageReader::with_format(std::io::Cursor::new(bytes), format);
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(max_dimension);
+    limits.max_image_height = Some(max_dimension);
+    limits.max_alloc = Some(MAX_FULL_FRAME_THUMBNAIL_BYTES);
+    reader.limits(limits);
+    let decoded = match reader.decode() {
+        Ok(decoded) => decoded,
+        Err(err) => {
+            debug_log(format!("clipboard thumbnail decode skipped: {err}"));
+            return None;
+        }
+    };
+
+    encode_thumbnail(decoded)
+}
+
+fn make_png_thumbnail(bytes: &Bytes) -> Option<ClipboardThumbnail> {
+    let mut decoder = png::Decoder::new_with_limits(
+        Cursor::new(bytes),
+        png::Limits {
+            bytes: max_image_bytes(),
+        },
+    );
+    decoder.set_ignore_text_chunk(true);
+    decoder.set_ignore_iccp_chunk(true);
+    decoder.set_transformations(png::Transformations::normalize_to_color8());
+
+    let mut reader = decoder.read_info().map_err(log_png_decode_error).ok()?;
+    let info = reader.info();
+    let (source_width, source_height) = (info.width, info.height);
+    if source_width == 0
+        || source_height == 0
+        || source_width > max_image_dimension_px()
+        || source_height > max_image_dimension_px()
+    {
         debug_log(format!(
-            "clipboard image ignored (dimensions exceed {} px)",
-            max_dimension
+            "clipboard thumbnail decode skipped: invalid dimensions {source_width}x{source_height}"
         ));
         return None;
     }
 
-    let format = match mime {
-        "image/png" => image::ImageFormat::Png,
-        "image/jpeg" => image::ImageFormat::Jpeg,
-        "image/webp" => image::ImageFormat::WebP,
-        _ => {
-            return image::load_from_memory(bytes)
-                .ok()
-                .and_then(encode_thumbnail_png);
+    if info.interlaced {
+        if reader.output_buffer_size()? as u64 > MAX_FULL_FRAME_THUMBNAIL_BYTES {
+            debug_log("clipboard thumbnail decode skipped: interlaced PNG frame is too large");
+            return None;
         }
-    };
+        return decode_png_frame(reader, source_width, source_height);
+    }
 
-    let decoded = image::load_from_memory_with_format(bytes, format)
-        .or_else(|_| image::load_from_memory(bytes))
+    let (width, height) = thumbnail_dimensions(source_width, source_height);
+    let channels = png_channels(reader.output_color_type())?;
+    let output_len = (width as usize)
+        .checked_mul(height as usize)?
+        .checked_mul(4)?;
+    let sample_x: Vec<usize> = (0..width)
+        .map(|x| sample_source_coordinate(x, width, source_width) as usize)
+        .collect();
+    let mut rgba = Vec::with_capacity(output_len);
+    let mut source_y = 0u32;
+    let mut output_y = 0u32;
+
+    while let Some(row) = reader.next_row().map_err(log_png_decode_error).ok()? {
+        if output_y < height
+            && source_y == sample_source_coordinate(output_y, height, source_height)
+        {
+            for source_x in &sample_x {
+                let offset = source_x.checked_mul(channels)?;
+                let end = offset.checked_add(channels)?;
+                rgba.extend_from_slice(&png_pixel_to_rgba(row.data().get(offset..end)?, channels));
+            }
+            output_y += 1;
+        }
+        source_y += 1;
+    }
+
+    if source_y != source_height || output_y != height || rgba.len() != output_len {
+        debug_log("clipboard thumbnail decode skipped: incomplete PNG image data");
+        return None;
+    }
+
+    encode_rgba_thumbnail(width, height, rgba)
+}
+
+fn decode_png_frame(
+    mut reader: png::Reader<Cursor<&Bytes>>,
+    width: u32,
+    height: u32,
+) -> Option<ClipboardThumbnail> {
+    let buffer_len = reader.output_buffer_size()?;
+    let mut decoded = vec![0; buffer_len];
+    let output = reader
+        .next_frame(&mut decoded)
+        .map_err(log_png_decode_error)
         .ok()?;
-
-    encode_thumbnail_png(decoded)
+    let decoded = match (output.color_type, output.bit_depth) {
+        (png::ColorType::Grayscale, png::BitDepth::Eight) => {
+            image::DynamicImage::ImageLuma8(image::ImageBuffer::from_raw(width, height, decoded)?)
+        }
+        (png::ColorType::GrayscaleAlpha, png::BitDepth::Eight) => {
+            image::DynamicImage::ImageLumaA8(image::ImageBuffer::from_raw(width, height, decoded)?)
+        }
+        (png::ColorType::Rgb, png::BitDepth::Eight) => {
+            image::DynamicImage::ImageRgb8(image::ImageBuffer::from_raw(width, height, decoded)?)
+        }
+        (png::ColorType::Rgba, png::BitDepth::Eight) => {
+            image::DynamicImage::ImageRgba8(image::ImageBuffer::from_raw(width, height, decoded)?)
+        }
+        _ => return None,
+    };
+    encode_thumbnail(decoded)
 }
 
-fn image_dimensions_within_limit(bytes: &[u8], max_dimension: u32) -> bool {
-    let Ok(reader) = image::ImageReader::new(std::io::Cursor::new(bytes)).with_guessed_format()
-    else {
-        return false;
-    };
-
-    let Ok((width, height)) = reader.into_dimensions() else {
-        return false;
-    };
-
-    width > 0 && height > 0 && width <= max_dimension && height <= max_dimension
+fn png_channels((color, depth): (png::ColorType, png::BitDepth)) -> Option<usize> {
+    (depth == png::BitDepth::Eight).then(|| color.samples())
 }
 
-fn encode_thumbnail_png(decoded: image::DynamicImage) -> Option<Vec<u8>> {
-    let thumb = decoded.thumbnail(THUMBNAIL_SIZE_PX, THUMBNAIL_SIZE_PX);
-    let mut out = Vec::new();
-    let mut cursor = Cursor::new(&mut out);
-    thumb.write_to(&mut cursor, image::ImageFormat::Png).ok()?;
-    Some(out)
+fn png_pixel_to_rgba(pixel: &[u8], channels: usize) -> [u8; 4] {
+    match channels {
+        1 => [pixel[0], pixel[0], pixel[0], 255],
+        2 => [pixel[0], pixel[0], pixel[0], pixel[1]],
+        3 => [pixel[0], pixel[1], pixel[2], 255],
+        4 => [pixel[0], pixel[1], pixel[2], pixel[3]],
+        _ => unreachable!("PNG decoder only produces 1-4 channels"),
+    }
+}
+
+fn thumbnail_dimensions(width: u32, height: u32) -> (u32, u32) {
+    if width <= THUMBNAIL_SIZE_PX && height <= THUMBNAIL_SIZE_PX {
+        return (width, height);
+    }
+
+    let scale =
+        (THUMBNAIL_SIZE_PX as f64 / width as f64).min(THUMBNAIL_SIZE_PX as f64 / height as f64);
+    (
+        (width as f64 * scale).round().max(1.0) as u32,
+        (height as f64 * scale).round().max(1.0) as u32,
+    )
+}
+
+fn sample_source_coordinate(value: u32, target_size: u32, source_size: u32) -> u32 {
+    let numerator = (u64::from(value) * 2 + 1) * u64::from(source_size);
+    let denominator = u64::from(target_size) * 2;
+    (numerator / denominator).min(u64::from(source_size - 1)) as u32
+}
+
+fn log_png_decode_error(err: png::DecodingError) {
+    debug_log(format!("clipboard thumbnail decode skipped: {err}"));
+}
+
+fn encode_thumbnail(decoded: image::DynamicImage) -> Option<ClipboardThumbnail> {
+    let thumb = if decoded.width() <= THUMBNAIL_SIZE_PX && decoded.height() <= THUMBNAIL_SIZE_PX {
+        decoded.into_rgba8()
+    } else {
+        decoded
+            .thumbnail(THUMBNAIL_SIZE_PX, THUMBNAIL_SIZE_PX)
+            .into_rgba8()
+    };
+    encode_rgba_thumbnail(thumb.width(), thumb.height(), thumb.into_raw())
+}
+
+fn encode_rgba_thumbnail(width: u32, height: u32, rgba: Vec<u8>) -> Option<ClipboardThumbnail> {
+    let mut png = Vec::new();
+    let mut encoder = png::Encoder::new(&mut png, width, height);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    encoder.set_compression(png::Compression::Fastest);
+    encoder.set_filter(png::Filter::NoFilter);
+    let mut writer = encoder.write_header().ok()?;
+    writer.write_image_data(&rgba).ok()?;
+    drop(writer);
+
+    Some(ClipboardThumbnail {
+        width,
+        height,
+        rgba: rgba.into(),
+        png: png.into(),
+    })
 }
 
 pub(super) fn log_image_too_large(len: usize) {

--- a/src/services/clipboard/io.rs
+++ b/src/services/clipboard/io.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use super::image::{
     clipboard_entry_from_image_bytes, clipboard_entry_from_image_path, log_image_too_large,
 };
@@ -101,6 +103,21 @@ pub fn write_clipboard_image(mime: &str, bytes: &[u8]) -> bool {
     match opts.copy(
         Source::Bytes(bytes.to_vec().into_boxed_slice()),
         CopyMimeType::Specific(mime.to_string()),
+    ) {
+        Ok(()) => true,
+        Err(err) => {
+            debug_log(format!("clipboard image write error: {err:?}"));
+            false
+        }
+    }
+}
+
+pub fn write_owned_clipboard_image(mime: String, bytes: bytes::Bytes) -> bool {
+    let opts = CopyOptions::new();
+    let bytes: Vec<u8> = bytes.into();
+    match opts.copy(
+        Source::Bytes(bytes.into_boxed_slice()),
+        CopyMimeType::Specific(mime),
     ) {
         Ok(()) => true,
         Err(err) => {

--- a/src/services/clipboard/model.rs
+++ b/src/services/clipboard/model.rs
@@ -1,12 +1,22 @@
+use bytes::Bytes;
+
 #[derive(Debug, Clone)]
 pub enum ClipboardEntry {
     Text(String),
     Image {
         mime: String,
-        bytes: Vec<u8>,
+        bytes: Bytes,
         hash: u64,
-        thumbnail_png: Option<Vec<u8>>,
+        thumbnail_png: Option<Bytes>,
     },
+}
+
+#[derive(Debug, Clone)]
+pub struct ClipboardThumbnail {
+    pub width: u32,
+    pub height: u32,
+    pub rgba: Bytes,
+    pub png: Bytes,
 }
 
 impl ClipboardEntry {

--- a/src/services/clipboard/tests.rs
+++ b/src/services/clipboard/tests.rs
@@ -14,9 +14,9 @@ fn image_entry(
 ) -> ClipboardEntry {
     ClipboardEntry::Image {
         mime: mime.to_string(),
-        bytes,
+        bytes: bytes.into(),
         hash,
-        thumbnail_png,
+        thumbnail_png: thumbnail_png.map(Into::into),
     }
 }
 
@@ -87,44 +87,103 @@ fn creates_image_entry_from_local_file_path() {
 }
 
 #[test]
-fn rejects_image_with_oversized_dimensions() {
+fn image_entry_defers_thumbnail_decoding() {
+    let img = RgbaImage::from_pixel(8, 4, Rgba([0, 255, 0, 255]));
+    let mut png = Vec::new();
+    DynamicImage::ImageRgba8(img)
+        .write_to(&mut Cursor::new(&mut png), ImageFormat::Png)
+        .expect("test image encoding should work");
+
+    let entry = super::image::clipboard_entry_from_image_bytes("image/png".to_string(), png)
+        .expect("image entry should be created");
+
+    match entry {
+        ClipboardEntry::Image { thumbnail_png, .. } => assert!(thumbnail_png.is_none()),
+        ClipboardEntry::Text(_) => panic!("expected image entry"),
+    }
+}
+
+#[test]
+fn builds_rgba_and_png_thumbnail_on_demand() {
+    let img = RgbaImage::from_pixel(8, 4, Rgba([0, 255, 0, 255]));
+    let mut png = Vec::new();
+    DynamicImage::ImageRgba8(img)
+        .write_to(&mut Cursor::new(&mut png), ImageFormat::Png)
+        .expect("test image encoding should work");
+
+    let thumbnail = super::make_thumbnail("image/png", &png.into())
+        .expect("valid image should produce a thumbnail");
+
+    assert_eq!((thumbnail.width, thumbnail.height), (8, 4));
+    assert_eq!(thumbnail.rgba.len(), 8 * 4 * 4);
+    assert!(thumbnail.png.starts_with(&[137, 80, 78, 71]));
+}
+
+fn encode_large_test_png() -> Vec<u8> {
+    let img = RgbaImage::from_fn(1024, 768, |x, y| {
+        let mixed = x
+            .wrapping_mul(0x9E37_79B9)
+            .wrapping_add(y.wrapping_mul(0x85EB_CA6B));
+        Rgba([
+            mixed as u8,
+            mixed.rotate_left(11) as u8,
+            mixed.rotate_left(21) as u8,
+            255,
+        ])
+    });
+    let mut png = Vec::new();
+    DynamicImage::ImageRgba8(img)
+        .write_to(&mut Cursor::new(&mut png), ImageFormat::Png)
+        .expect("test image encoding should work");
+    png
+}
+
+#[test]
+fn streams_large_png_directly_into_bounded_thumbnail_storage() {
+    let png = encode_large_test_png();
+
+    let thumbnail = super::make_thumbnail("image/png", &png.into())
+        .expect("valid large PNG should produce a thumbnail");
+
+    assert_eq!((thumbnail.width, thumbnail.height), (400, 300));
+    assert_eq!(thumbnail.rgba.len(), 400 * 300 * 4);
+}
+
+#[test]
+#[ignore = "manual benchmark for the 2-4 MiB clipboard-image workload"]
+fn benchmark_large_png_thumbnail_decode() {
+    let png = encode_large_test_png();
+    assert!(
+        (2 * 1024 * 1024..=4 * 1024 * 1024).contains(&png.len()),
+        "benchmark PNG is {} bytes",
+        png.len()
+    );
+
+    let started = std::time::Instant::now();
+    let thumbnail = super::make_thumbnail("image/png", &png.into())
+        .expect("benchmark PNG should produce a thumbnail");
+    eprintln!(
+        "decoded 2-4 MiB PNG into {}x{} thumbnail in {:?}",
+        thumbnail.width,
+        thumbnail.height,
+        started.elapsed()
+    );
+}
+
+#[test]
+fn rejects_thumbnail_with_oversized_dimensions() {
     let huge = RgbaImage::from_pixel(9000, 1, Rgba([255, 0, 0, 255]));
     let mut png = Vec::new();
     DynamicImage::ImageRgba8(huge)
         .write_to(&mut Cursor::new(&mut png), ImageFormat::Png)
         .expect("huge test image encoding should work");
 
-    let entry = super::image::clipboard_entry_from_image_bytes("image/png".to_string(), png)
-        .expect("image entry should still be created");
-
-    match entry {
-        ClipboardEntry::Image { thumbnail_png, .. } => {
-            assert!(
-                thumbnail_png.is_none(),
-                "oversized-dimension image should not generate thumbnail"
-            );
-        }
-        ClipboardEntry::Text(_) => panic!("expected image entry"),
-    }
+    assert!(super::make_thumbnail("image/png", &png.into()).is_none());
 }
 
 #[test]
 fn rejects_malformed_image_bytes_for_thumbnail() {
-    let entry = super::image::clipboard_entry_from_image_bytes(
-        "image/png".to_string(),
-        vec![1, 2, 3, 4, 5, 6, 7],
-    )
-    .expect("entry should still be created with raw bytes");
-
-    match entry {
-        ClipboardEntry::Image { thumbnail_png, .. } => {
-            assert!(
-                thumbnail_png.is_none(),
-                "malformed image should not generate thumbnail"
-            );
-        }
-        ClipboardEntry::Text(_) => panic!("expected image entry"),
-    }
+    assert!(super::make_thumbnail("image/png", &vec![1, 2, 3, 4, 5, 6, 7].into()).is_none());
 }
 
 fn wayland_tests_enabled() -> bool {

--- a/src/services/clipboard/watcher.rs
+++ b/src/services/clipboard/watcher.rs
@@ -1,0 +1,437 @@
+//! Event driven Wayland clipboard watcher.
+//!
+//! `wl_clipboard_rs::paste::get_contents` is intentionally a short lived helper: every call
+//! creates a new data-control connection and asks the current offer to send its data.  That is
+//! the wrong primitive for a clipboard history, which only needs to read an offer once when the
+//! selection changes.  This module keeps one data-control connection alive and receives the
+//! selection event from it.
+
+use super::image::{
+    clipboard_entry_from_image_bytes, clipboard_entry_from_image_path, log_image_too_large,
+};
+use super::uri::parse_first_local_path_from_uri_list;
+use super::{ClipboardEntry, debug_log, max_image_bytes};
+use os_pipe::pipe;
+use std::collections::HashMap;
+use std::io::Read;
+use std::os::fd::AsFd;
+use wayland_client::globals::{GlobalListContents, registry_queue_init};
+use wayland_client::protocol::wl_registry::WlRegistry;
+use wayland_client::protocol::wl_seat::{self, WlSeat};
+use wayland_client::{Connection, Dispatch, EventQueue, Proxy, event_created_child};
+use wayland_protocols::ext::data_control::v1::client as ext;
+use wayland_protocols_wlr::data_control::v1::client as zwlr;
+
+#[derive(Clone)]
+enum Manager {
+    Wlr(zwlr::zwlr_data_control_manager_v1::ZwlrDataControlManagerV1),
+    Ext(ext::ext_data_control_manager_v1::ExtDataControlManagerV1),
+}
+
+#[derive(Clone)]
+enum Device {
+    Wlr(zwlr::zwlr_data_control_device_v1::ZwlrDataControlDeviceV1),
+    Ext(ext::ext_data_control_device_v1::ExtDataControlDeviceV1),
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+enum Offer {
+    Wlr(zwlr::zwlr_data_control_offer_v1::ZwlrDataControlOfferV1),
+    Ext(ext::ext_data_control_offer_v1::ExtDataControlOfferV1),
+}
+
+impl From<zwlr::zwlr_data_control_offer_v1::ZwlrDataControlOfferV1> for Offer {
+    fn from(value: zwlr::zwlr_data_control_offer_v1::ZwlrDataControlOfferV1) -> Self {
+        Self::Wlr(value)
+    }
+}
+
+impl From<ext::ext_data_control_offer_v1::ExtDataControlOfferV1> for Offer {
+    fn from(value: ext::ext_data_control_offer_v1::ExtDataControlOfferV1) -> Self {
+        Self::Ext(value)
+    }
+}
+
+impl Offer {
+    fn destroy(&self) {
+        match self {
+            Self::Wlr(offer) => offer.destroy(),
+            Self::Ext(offer) => offer.destroy(),
+        }
+    }
+
+    fn receive(&self, mime: String, fd: std::os::fd::BorrowedFd<'_>) {
+        match self {
+            Self::Wlr(offer) => offer.receive(mime, fd),
+            Self::Ext(offer) => offer.receive(mime, fd),
+        }
+    }
+}
+
+impl Manager {
+    fn get_data_device<D>(
+        &self,
+        seat: &WlSeat,
+        qh: &wayland_client::QueueHandle<D>,
+        data: WlSeat,
+    ) -> Device
+    where
+        D: Dispatch<zwlr::zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, WlSeat>
+            + Dispatch<ext::ext_data_control_device_v1::ExtDataControlDeviceV1, WlSeat>
+            + 'static,
+    {
+        match self {
+            Self::Wlr(manager) => Device::Wlr(manager.get_data_device(seat, qh, data)),
+            Self::Ext(manager) => Device::Ext(manager.get_data_device(seat, qh, data)),
+        }
+    }
+}
+
+impl Device {
+    fn destroy(&self) {
+        match self {
+            Self::Wlr(device) => device.destroy(),
+            Self::Ext(device) => device.destroy(),
+        }
+    }
+}
+
+#[derive(Default)]
+struct SeatState {
+    device: Option<Device>,
+    selected: Option<Offer>,
+}
+
+struct State {
+    manager: Manager,
+    seats: HashMap<WlSeat, SeatState>,
+    offers: HashMap<Offer, Vec<String>>,
+    pending: Option<Option<Offer>>,
+    current: Option<Offer>,
+}
+
+impl Dispatch<WlRegistry, GlobalListContents> for State {
+    fn event(
+        _state: &mut Self,
+        _proxy: &WlRegistry,
+        _event: <WlRegistry as Proxy>::Event,
+        _data: &GlobalListContents,
+        _conn: &Connection,
+        _qh: &wayland_client::QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<zwlr::zwlr_data_control_manager_v1::ZwlrDataControlManagerV1, ()> for State {
+    fn event(
+        _state: &mut Self,
+        _proxy: &zwlr::zwlr_data_control_manager_v1::ZwlrDataControlManagerV1,
+        _event: <zwlr::zwlr_data_control_manager_v1::ZwlrDataControlManagerV1 as Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &wayland_client::QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<ext::ext_data_control_manager_v1::ExtDataControlManagerV1, ()> for State {
+    fn event(
+        _state: &mut Self,
+        _proxy: &ext::ext_data_control_manager_v1::ExtDataControlManagerV1,
+        _event: <ext::ext_data_control_manager_v1::ExtDataControlManagerV1 as Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &wayland_client::QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<WlSeat, ()> for State {
+    fn event(
+        state: &mut Self,
+        seat: &WlSeat,
+        event: wl_seat::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &wayland_client::QueueHandle<Self>,
+    ) {
+        if let wl_seat::Event::Name { .. } = event {
+            // The name is not needed: this watcher observes the first seat, as the existing
+            // wl-clipboard-rs API does for `Seat::Unspecified`.
+            let _ = state.seats.get(seat);
+        }
+    }
+}
+
+macro_rules! impl_device_dispatch {
+    ($iface:ty, $offer_iface:ty, $offer_opcode:path) => {
+        impl Dispatch<$iface, WlSeat> for State {
+            fn event(state: &mut Self, _proxy: &$iface, event: <$iface as Proxy>::Event, seat: &WlSeat, _conn: &Connection, _qh: &wayland_client::QueueHandle<Self>) {
+                type Event = <$iface as Proxy>::Event;
+                match event {
+                    Event::DataOffer { id } => {
+                        state.offers.insert(Offer::from(id), Vec::new());
+                    }
+                    Event::Selection { id } => {
+                        let next = id.map(Offer::from);
+                        if state.current == next {
+                            return;
+                        }
+                        state.current = next.clone();
+                        state.pending = Some(next);
+                        if let Some(data) = state.seats.get_mut(seat) {
+                            if let Some(old) = data.selected.take() {
+                                if Some(old.clone()) != state.current {
+                                    old.destroy();
+                                    state.offers.remove(&old);
+                                } else {
+                                    data.selected = Some(old);
+                                }
+                            }
+                            data.selected = state.pending.clone().flatten();
+                        }
+                    }
+                    Event::Finished => {
+                        if let Some(data) = state.seats.get_mut(seat) {
+                            data.device = None;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            event_created_child!(State, $iface, [$offer_opcode => ($offer_iface, ())]);
+        }
+    };
+}
+
+impl_device_dispatch!(
+    zwlr::zwlr_data_control_device_v1::ZwlrDataControlDeviceV1,
+    zwlr::zwlr_data_control_offer_v1::ZwlrDataControlOfferV1,
+    zwlr::zwlr_data_control_device_v1::EVT_DATA_OFFER_OPCODE
+);
+impl_device_dispatch!(
+    ext::ext_data_control_device_v1::ExtDataControlDeviceV1,
+    ext::ext_data_control_offer_v1::ExtDataControlOfferV1,
+    ext::ext_data_control_device_v1::EVT_DATA_OFFER_OPCODE
+);
+
+macro_rules! impl_offer_dispatch {
+    ($iface:ty) => {
+        impl Dispatch<$iface, ()> for State {
+            fn event(
+                state: &mut Self,
+                offer: &$iface,
+                event: <$iface as Proxy>::Event,
+                _data: &(),
+                _conn: &Connection,
+                _qh: &wayland_client::QueueHandle<Self>,
+            ) {
+                type Event = <$iface as Proxy>::Event;
+                if let Event::Offer { mime_type } = event {
+                    if let Some(mimes) = state.offers.get_mut(&Offer::from(offer.clone())) {
+                        mimes.push(mime_type);
+                    }
+                }
+            }
+        }
+    };
+}
+
+impl_offer_dispatch!(zwlr::zwlr_data_control_offer_v1::ZwlrDataControlOfferV1);
+impl_offer_dispatch!(ext::ext_data_control_offer_v1::ExtDataControlOfferV1);
+
+fn choose_mime(mimes: &[String]) -> Option<String> {
+    const PREFERRED: [&str; 6] = [
+        "image/png",
+        "image/jpeg",
+        "image/webp",
+        "text/uri-list",
+        "text/plain;charset=utf-8",
+        "UTF8_STRING",
+    ];
+    PREFERRED
+        .iter()
+        .find_map(|preferred| {
+            mimes
+                .iter()
+                .find(|mime| mime.as_str() == *preferred)
+                .cloned()
+        })
+        .or_else(|| {
+            mimes
+                .iter()
+                .find(|mime| mime.starts_with("text/plain"))
+                .cloned()
+        })
+}
+
+fn read_offer(offer: &Offer, mime: String, queue: &EventQueue<State>) -> Option<ClipboardEntry> {
+    let (mut reader, writer) = pipe().ok()?;
+    offer.receive(mime.clone(), writer.as_fd());
+    drop(writer);
+    queue.flush().ok()?;
+
+    let mut bytes = Vec::new();
+    if mime.starts_with("image/") {
+        let max = max_image_bytes();
+        if reader
+            .take((max + 1) as u64)
+            .read_to_end(&mut bytes)
+            .is_err()
+        {
+            return None;
+        }
+        if bytes.len() > max {
+            log_image_too_large(bytes.len());
+            return None;
+        }
+        return clipboard_entry_from_image_bytes(mime, bytes);
+    }
+
+    if reader.read_to_end(&mut bytes).is_err() {
+        return None;
+    }
+    if mime == "text/uri-list" {
+        let uris = String::from_utf8(bytes).ok()?;
+        let path = parse_first_local_path_from_uri_list(&uris)?;
+        return clipboard_entry_from_image_path(&path);
+    }
+    let text = String::from_utf8(bytes)
+        .ok()?
+        .trim_end_matches(['\n', '\r'])
+        .to_string();
+    (!text.is_empty()).then_some(ClipboardEntry::Text(text))
+}
+
+/// Runs until the subscription is dropped.  There is one Wayland connection for the lifetime of
+/// this function; the current offer is read only after a `selection` event arrives.
+pub fn run(sender: tokio::sync::mpsc::Sender<ClipboardEntry>) {
+    let Ok(conn) = Connection::connect_to_env() else {
+        debug_log("clipboard watcher: unable to connect to Wayland");
+        return;
+    };
+    let Ok((globals, mut queue)) = registry_queue_init::<State>(&conn) else {
+        debug_log("clipboard watcher: unable to initialise Wayland globals");
+        return;
+    };
+    let qh = queue.handle();
+    let ext_manager = globals
+        .bind::<ext::ext_data_control_manager_v1::ExtDataControlManagerV1, _, _>(&qh, 1..=1, ())
+        .ok()
+        .map(Manager::Ext);
+    let manager = ext_manager.or_else(|| {
+        globals
+            .bind::<zwlr::zwlr_data_control_manager_v1::ZwlrDataControlManagerV1, _, _>(
+                &qh,
+                1..=1,
+                (),
+            )
+            .ok()
+            .map(Manager::Wlr)
+    });
+    let Some(manager) = manager else {
+        debug_log("clipboard watcher: data-control protocol unavailable");
+        return;
+    };
+
+    let registry = globals.registry();
+    #[allow(clippy::mutable_key_type)]
+    let mut seats = HashMap::new();
+    globals.contents().with_list(|list| {
+        if let Some(global) = list
+            .iter()
+            .find(|g| g.interface == WlSeat::interface().name && g.version >= 2)
+        {
+            let seat = registry.bind(global.name, 2, &qh, ());
+            seats.insert(seat, SeatState::default());
+        }
+    });
+    if seats.is_empty() {
+        debug_log("clipboard watcher: no Wayland seats");
+        return;
+    }
+
+    #[allow(clippy::mutable_key_type)]
+    let mut state = State {
+        manager,
+        seats,
+        offers: HashMap::new(),
+        pending: None,
+        current: None,
+    };
+    let seat_list: Vec<WlSeat> = state.seats.keys().cloned().collect();
+    for seat in seat_list {
+        let device = state.manager.get_data_device(&seat, &qh, seat.clone());
+        state.seats.get_mut(&seat).unwrap().device = Some(device);
+    }
+    if queue.roundtrip(&mut state).is_err() {
+        return;
+    }
+
+    loop {
+        if let Some(Some(offer)) = state.pending.take()
+            && let Some(mime) = state
+                .offers
+                .get(&offer)
+                .and_then(|mimes| choose_mime(mimes))
+            && let Some(entry) = read_offer(&offer, mime, &queue)
+        {
+            // A new selection can arrive while the owner is producing a large
+            // image.  Dispatch already-buffered events before publishing the old
+            // bytes, and discard them if the offer is no longer current.
+            if queue.dispatch_pending(&mut state).is_err() {
+                break;
+            }
+            if state.current.as_ref() != Some(&offer) {
+                continue;
+            }
+            if sender.blocking_send(entry).is_err() {
+                break;
+            }
+        }
+        if queue.blocking_dispatch(&mut state).is_err() {
+            break;
+        }
+    }
+
+    for data in state.seats.values() {
+        if let Some(device) = &data.device {
+            device.destroy();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::choose_mime;
+
+    fn mimes(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn prefers_png_then_jpeg_before_text() {
+        assert_eq!(
+            choose_mime(&mimes(&["text/plain", "image/jpeg"])),
+            Some("image/jpeg".into())
+        );
+        assert_eq!(
+            choose_mime(&mimes(&["image/jpeg", "image/png"])),
+            Some("image/png".into())
+        );
+    }
+
+    #[test]
+    fn falls_back_to_uri_list_and_plain_text() {
+        assert_eq!(
+            choose_mime(&mimes(&["text/plain", "text/uri-list"])),
+            Some("text/uri-list".into())
+        );
+        assert_eq!(
+            choose_mime(&mimes(&["text/plain;charset=utf-8"])),
+            Some("text/plain;charset=utf-8".into())
+        );
+        assert_eq!(choose_mime(&mimes(&["application/octet-stream"])), None);
+    }
+}


### PR DESCRIPTION
## The Problem

clippy-land periodically requested the current clipboard image again, even when the Wayland selection had not changed.

For large images, this forced the clipboard owner,  for example, Telegram - to encode and send the same PNG every 1.5 seconds. This caused high CPU usage and made the source application slow. 

##  The PR:

  - keeps a persistent Wayland data-control connection;
  - listens for selection changes instead of polling;
  - requests clipboard data only once for each new selection;
  - stores the received bytes for history and previews;
  - ignores data from an old offer if the selection changes during transfer;
  - decodes image thumbnails outside the UI thread;
  - limits image reads and generates thumbnails on demand.

Both ext-data-control-v1 and wlr-data-control-unstable-v1 are supported.

## Expected result

After copying a large image, the clipboard owner should receive only one send("image/…") request for that selection. Its background CPU usage should return to nearly zero after the image has been transferred.

## Manual verification

Run the clipboard owner with Wayland logging enabled, copy a large image, and check:


$ `WAYLAND_DEBUG=1 ./Telegram 2>>log.log`
$ `tail log.log -f | grep "send(\"image/png\""`
or
$ `rg 'wl_data_source.*send' log.log`

There should be one image send per new clipboard selection, rather than repeated requests every ~1.5 seconds.
